### PR TITLE
Read username/password from auth param

### DIFF
--- a/dist/prometheus-query.cjs.js
+++ b/dist/prometheus-query.cjs.js
@@ -302,8 +302,8 @@ class PrometheusQuery {
             data: body,
             headers: this.headers,
             auth: {
-                username: this.proxy.username,
-                password: this.proxy.password
+                username: this.auth.username,
+                password: this.auth.password
             },
             proxy: (!!this.proxy.host && !!this.proxy.port) ? {
                 host: this.proxy.host,

--- a/dist/prometheus-query.esm.js
+++ b/dist/prometheus-query.esm.js
@@ -298,8 +298,8 @@ class PrometheusQuery {
             data: body,
             headers: this.headers,
             auth: {
-                username: this.proxy.username,
-                password: this.proxy.password
+                username: this.auth.username,
+                password: this.auth.password
             },
             proxy: (!!this.proxy.host && !!this.proxy.port) ? {
                 host: this.proxy.host,

--- a/dist/prometheus-query.umd.js
+++ b/dist/prometheus-query.umd.js
@@ -1726,8 +1726,8 @@
               data: body,
               headers: this.headers,
               auth: {
-                  username: this.proxy.username,
-                  password: this.proxy.password
+                  username: this.auth.username,
+                  password: this.auth.password
               },
               proxy: (!!this.proxy.host && !!this.proxy.port) ? {
                   host: this.proxy.host,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "prometheus-query",
-    "version": "1.0.1",
+    "version": "2.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "prometheus-query",
     "description": "A Javascript client for Prometheus query API",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "main": "dist/prometheus-query.cjs.js",
     "module": "dist/prometheus-query.esm.js",
     "browser": "dist/prometheus-query.umd.js",

--- a/src/index.js
+++ b/src/index.js
@@ -47,8 +47,8 @@ export default class PrometheusQuery {
             data: body,
             headers: this.headers,
             auth: {
-                username: this.proxy.username,
-                password: this.proxy.password
+                username: this.auth.username,
+                password: this.auth.password
             },
             proxy: (!!this.proxy.host && !!this.proxy.port) ? {
                 host: this.proxy.host,


### PR DESCRIPTION
Fixes samber/prometheus-query-js#3

The username/password are currently read from the proxy parameter object, and the auth parameter object was not used.

Change to read username and password from the auth parameter object.