### PR TITLE
Don't set auth if no user/pass

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,10 +46,10 @@ export default class PrometheusQuery {
             params: params,
             data: body,
             headers: this.headers,
-            auth: {
+            auth: (!!this.auth.username && !!this.auth.password) ? {
                 username: this.auth.username,
                 password: this.auth.password
-            },
+            } : null,
             proxy: (!!this.proxy.host && !!this.proxy.port) ? {
                 host: this.proxy.host,
                 port: this.proxy.port


### PR DESCRIPTION
I'm using cookie based auth to connect to a prometheus endpoint. Not setting a auth means the request gets sent with a  `Authorization: Basic Og==` header. This results in a 401 from my Prometheus endpoint.

This is because axios adds the auth header based on the presense of the auth object, not if it has username or password in it. https://github.com/axios/axios/blob/c7329fefc890050edd51e40e469a154d0117fc55/lib/adapters/http.js#L32.

This PR adds a similar check as what is in place for the proxy config.

Cheers