### PR TITLE
Make start and end optional for labelValues

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -261,8 +261,8 @@ export class PrometheusDriver {
     public labelValues(labelName: string, matchs?: SerieSelector, start?: PrometheusQueryDate, end?: PrometheusQueryDate): Promise<string[]> {
         const params = {
             match: this.listifyIfNeeded(matchs),
-            start: this.formatTimeToPrometheus(start),
-            end: this.formatTimeToPrometheus(end),
+            start: this.formatTimeToPrometheus(start, new Date()),
+            end: this.formatTimeToPrometheus(end, new Date()),
         }
 
         return this.request('GET', `label/${labelName}/values`, params)


### PR DESCRIPTION
Not passing the `matchs`, `start`, and `end` to `labelValues` resulted in an error.

That's what happens when there are [no tests](https://github.com/samber/prometheus-query-js/blob/master/test/test.js).