### PR TITLE
RangeQuery: adding support for duration format for "step" argument

### DIFF
--- a/dist/driver.d.ts
+++ b/dist/driver.d.ts
@@ -63,10 +63,10 @@ export declare class PrometheusDriver {
      * @param {*} query Prometheus expression query string.
      * @param {*} start Start Date object or number in milliseconds.
      * @param {*} end End Date object or number in milliseconds.
-     * @param {*} step Query resolution step width in number of seconds.
+     * @param {*} step Query resolution step width in duration format or number of seconds.
      * @param {*} timeout Evaluation timeout string. Optional.
      */
-    rangeQuery(query: string, start: PrometheusQueryDate, end: PrometheusQueryDate, step: number, timeout?: string): Promise<QueryResult>;
+    rangeQuery(query: string, start: PrometheusQueryDate, end: PrometheusQueryDate, step: string | number, timeout?: string): Promise<QueryResult>;
     /***********************  METADATA API  ***********************/
     /**
      * Finding series by label matchers

--- a/dist/prometheus-query.cjs.js
+++ b/dist/prometheus-query.cjs.js
@@ -319,7 +319,7 @@ class PrometheusDriver {
      * @param {*} query Prometheus expression query string.
      * @param {*} start Start Date object or number in milliseconds.
      * @param {*} end End Date object or number in milliseconds.
-     * @param {*} step Query resolution step width in number of seconds.
+     * @param {*} step Query resolution step width in duration format or number of seconds.
      * @param {*} timeout Evaluation timeout string. Optional.
      */
     rangeQuery(query, start, end, step, timeout) {

--- a/dist/prometheus-query.esm.js
+++ b/dist/prometheus-query.esm.js
@@ -311,7 +311,7 @@ class PrometheusDriver {
      * @param {*} query Prometheus expression query string.
      * @param {*} start Start Date object or number in milliseconds.
      * @param {*} end End Date object or number in milliseconds.
-     * @param {*} step Query resolution step width in number of seconds.
+     * @param {*} step Query resolution step width in duration format or number of seconds.
      * @param {*} timeout Evaluation timeout string. Optional.
      */
     rangeQuery(query, start, end, step, timeout) {

--- a/dist/prometheus-query.umd.js
+++ b/dist/prometheus-query.umd.js
@@ -1,5 +1,5 @@
 /*!
- * prometheus-query v3.2.5
+ * prometheus-query v3.3.0
  * github.com/samber/prometheus-query-js
  * (c) 2022 prometheus-query-js Contributors
  * Released under the MIT License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prometheus-query",
-    "version": "3.2.5",
+    "version": "3.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prometheus-query",
-            "version": "3.2.5",
+            "version": "3.3.0",
             "license": "MIT",
             "dependencies": {
                 "axios": "^0.26.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "prometheus-query",
     "description": "A Javascript client for Prometheus query API",
-    "version": "3.2.5",
+    "version": "3.3.0",
     "main": "dist/prometheus-query.cjs.js",
     "module": "dist/prometheus-query.esm.js",
     "browser": "dist/prometheus-query.umd.js",

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -192,10 +192,10 @@ export class PrometheusDriver {
      * @param {*} query Prometheus expression query string.
      * @param {*} start Start Date object or number in milliseconds.
      * @param {*} end End Date object or number in milliseconds.
-     * @param {*} step Query resolution step width in number of seconds.
+     * @param {*} step Query resolution step width in duration format or number of seconds.
      * @param {*} timeout Evaluation timeout string. Optional.
      */
-    public rangeQuery(query: string, start: PrometheusQueryDate, end: PrometheusQueryDate, step: number, timeout?: string): Promise<QueryResult> {
+    public rangeQuery(query: string, start: PrometheusQueryDate, end: PrometheusQueryDate, step: string | number, timeout?: string): Promise<QueryResult> {
         const params = {
             query,
             start: this.formatTimeToPrometheus(start),


### PR DESCRIPTION
Closing #23